### PR TITLE
Refactor AutoRoute according to new implementatiaon

### DIFF
--- a/lib/presentation/core/app_widget.dart
+++ b/lib/presentation/core/app_widget.dart
@@ -10,6 +10,7 @@ import 'package:notes_firebase_ddd_course/presentation/sign_in/sign_in_page.dart
 class AppWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final _appRouter = app_router.Router();
     return MultiBlocProvider(
       providers: [
         BlocProvider(
@@ -17,10 +18,11 @@ class AppWidget extends StatelessWidget {
               getIt<AuthBloc>()..add(const AuthEvent.authCheckRequested()),
         )
       ],
-      child: MaterialApp(
+      child: MaterialApp.router(
+        routerDelegate: AutoRouterDelegate(_appRouter),
+        routeInformationParser: _appRouter.defaultRouteParser(),
         title: 'Notes',
-        debugShowCheckedModeBanner: false,
-        builder: ExtendedNavigator.builder(router: app_router.Router()),
+        debugShowCheckedModeBanner: false,        
         theme: ThemeData.light().copyWith(
           primaryColor: Colors.green[800],
           accentColor: Colors.blueAccent,

--- a/lib/presentation/routes/router.dart
+++ b/lib/presentation/routes/router.dart
@@ -4,13 +4,12 @@ import 'package:notes_firebase_ddd_course/presentation/notes/notes_overview/note
 import 'package:notes_firebase_ddd_course/presentation/sign_in/sign_in_page.dart';
 import 'package:notes_firebase_ddd_course/presentation/splash/splash_page.dart';
 
-@MaterialAutoRouter(
-  generateNavigationHelperExtension: true,
+@MaterialAutoRouter( 
   routes: <AutoRoute>[
-    MaterialRoute(page: SplashPage, initial: true),
-    MaterialRoute(page: SignInPage),
-    MaterialRoute(page: NotesOverviewPage),
-    MaterialRoute(page: NoteFormPage, fullscreenDialog: true),
+    AutoRoute(page: SplashPage, initial: true),
+    AutoRoute(page: SignInPage),
+    AutoRoute(page: NotesOverviewPage),
+    AutoRoute(page: NoteFormPage, fullscreenDialog: true),
   ],
 )
 class $Router {}

--- a/lib/presentation/splash/splash_page.dart
+++ b/lib/presentation/splash/splash_page.dart
@@ -12,9 +12,11 @@ class SplashPage extends StatelessWidget {
         state.map(
           initial: (_) {},
           authenticated: (_) =>
-              ExtendedNavigator.of(context).replace(Routes.notesOverviewPage),
+              context.router.replace(NotesOverviewPage(),
+                                    ),
           unauthenticated: (_) =>
-              ExtendedNavigator.of(context).replace(Routes.signInPage),
+               context.router.replace(SignInPageRoute(),
+                                     ),
         );
       },
       child: const Scaffold(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  auto_route: ^0.6.9
+  auto_route: ^2.3.0
   cloud_firestore: ^0.14.0+2
   dartz: ^0.9.1
   firebase_auth: ^0.18.0+1


### PR DESCRIPTION
1. Replace builder ExtendedNavigator with AutoRouterDelegate and routeInformationParser in app_widget.dart.
2. Deleted generateNavigationHelperExtension in router.dart.
3. Replaced MaterialRoute with AutoRoute in router.dart.
4. Replaced ExtendedNavigator.of(context).replace with context.router.replace in splash_page.dart.
5. Update auto_route version in pubspec.yaml.